### PR TITLE
Store ranges and symbols separately for each document

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import {
     decrementContext
 } from './modify-context';
 import * as PascuaneseFunctions from './pascuanese-functions';
-import { OrgFoldingAndOutlineProvider } from './org-folding-and-outline-provider';
+import { OrgFoldingAndOutlineProvider, OrgFoldingAndOutlineDocumentStateRegistry } from './org-folding-and-outline-provider';
 
 export function activate(context: vscode.ExtensionContext) {
     let insertHeadingRespectContentCmd = vscode.commands.registerTextEditorCommand('org.insertHeadingRespectContent', HeaderFunctions.insertHeadingRespectContent);
@@ -57,7 +57,8 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(literalCmd);
     context.subscriptions.push(butterflyCmd);
 
-    let provider = new OrgFoldingAndOutlineProvider();
+    let registry: OrgFoldingAndOutlineDocumentStateRegistry = new WeakMap();
+    let provider = new OrgFoldingAndOutlineProvider(registry);
     vscode.languages.registerFoldingRangeProvider('org', provider);
     vscode.languages.registerDocumentSymbolProvider('org', provider);
 }


### PR DESCRIPTION
This allows to keep cached ranges and symbols when editing several org
files at once, switching between them will not overwrite the other
file's cached ranges and symbols.

`TextDocument.version` is used to detect content changes. This is less
accurate (because undo and redo actions increment the version number
too), but does not require to have a copy of the whole document.